### PR TITLE
Feature/CC-SP2-101.3 Dispatch call for add cab

### DIFF
--- a/pallets/carpooling/src/tests.rs
+++ b/pallets/carpooling/src/tests.rs
@@ -57,3 +57,47 @@ fn update_cab_location_fail() {
         )
     });
 }
+#[test]
+fn add_new_cab() {
+    new_test_ext().execute_with(|| {
+        let new_cab = SDriver {
+            id: 32,
+            car_no: "2345".using_encoded(<Test as frame_system::Config>::Hashing::hash),
+            location: (20, 30),
+            price: 12,
+        };
+        // Dispatch a signed extrinsic.
+        assert_eq!(
+            Carpooling::add_new_cab(Origin::signed(1), 42, new_cab),
+            Ok(())
+        );
+        // Read pallet storage and assert an expected result.
+    });
+}
+#[test]
+fn add_new_cab_fails() {
+    new_test_ext().execute_with(|| {
+        let new_cab = SDriver {
+            id: 32,
+            car_no: "2345".using_encoded(<Test as frame_system::Config>::Hashing::hash),
+            location: (20, 30),
+            price: 12,
+        };
+        // Dispatch a signed extrinsic.
+        assert_ok!(Carpooling::add_new_cab(Origin::signed(1), 42, new_cab));
+        let new_cab_1 = SDriver {
+            id: 32,
+            car_no: "2345".using_encoded(<Test as frame_system::Config>::Hashing::hash),
+            location: (20, 30),
+            price: 12,
+        };
+        assert_eq!(
+            Carpooling::add_new_cab(Origin::signed(1), 42, new_cab_1),
+            Err(DispatchError::Module {
+                index: 1,
+                error: 1,
+                message: Some("CabAlreadyExist")
+            })
+        );
+    });
+}


### PR DESCRIPTION
What does this change do?
add a dispatch call to add Cab.
Any additional information for the reviewer to start
NA
How should this be manually tested?
We need the window OS in which Rust is installed. then execute this rust program
Which Trello task and sub-task does this change relate to?
CC - SP2 101.3 - Add dispatch call for add_cab
Are there any changes pending?
No
Does any team have to be notified of changes in this feature?
Yes
Definition of Done:
- [ ] Is there >90% unit test code coverage?
6.19%
- [ ] Does this PR add new dependencies? If so, please list out the same.
- [ ] Will this feature require a new piece of infrastructure to be implemented?
- [x] Is there appropriate logging included?
- [x] Does the project compile ok?
- [x] Have Clippy violations been fixed?
- [x] Have Code is properly formatted?