### PR TITLE
 Feature/CC-SP2-101.1.0-Add-Destination-Field-in-SDriver-Struct

### DIFF
--- a/pallets/carpooling/src/lib.rs
+++ b/pallets/carpooling/src/lib.rs
@@ -36,6 +36,7 @@ pub mod pallet {
         pub car_no: Hash,
         pub location: (u32, u32),
         pub price: u32,
+        pub destination: (u32, u32),
     }
     /// Configure the pallet by specifying the parameters and types on which it depends.
     #[pallet::config]

--- a/pallets/carpooling/src/tests.rs
+++ b/pallets/carpooling/src/tests.rs
@@ -26,6 +26,7 @@ fn update_cab_location_success() {
             car_no: "UP76 E 8559".using_encoded(<Test as frame_system::Config>::Hashing::hash),
             location: (20, 30),
             price: 20,
+            destination: (40,40),
         };
         let new_location: (u32, u32) = (40, 40);
         let new_driver = SDriver {
@@ -33,6 +34,7 @@ fn update_cab_location_success() {
             car_no: "UP76 E 8559".using_encoded(<Test as frame_system::Config>::Hashing::hash),
             location: new_location,
             price: 20,
+            destination: (40,40),
         };
         Driver::<Test>::insert(10, old_driver);
         assert_ok!(Carpooling::update_cab_location(
@@ -65,6 +67,7 @@ fn add_new_cab() {
             car_no: "2345".using_encoded(<Test as frame_system::Config>::Hashing::hash),
             location: (20, 30),
             price: 12,
+            destination: (40,40),
         };
         // Dispatch a signed extrinsic.
         assert_eq!(
@@ -82,6 +85,7 @@ fn add_new_cab_fails() {
             car_no: "2345".using_encoded(<Test as frame_system::Config>::Hashing::hash),
             location: (20, 30),
             price: 12,
+            destination: (30,30),
         };
         // Dispatch a signed extrinsic.
         assert_ok!(Carpooling::add_new_cab(Origin::signed(1), 42, new_cab));
@@ -90,6 +94,7 @@ fn add_new_cab_fails() {
             car_no: "2345".using_encoded(<Test as frame_system::Config>::Hashing::hash),
             location: (20, 30),
             price: 12,
+            destination: (30,40),
         };
         assert_eq!(
             Carpooling::add_new_cab(Origin::signed(1), 42, new_cab_1),


### PR DESCRIPTION
What does this change do?
add destination field in SDriver struct

Any additional information for the reviewer to start
NA

How should this be manually tested?
We need the window OS in which Rust is installed. then execute this rust program

Which Trello task and sub-task does this change relate to?
CC-SP2-101.1.0-Add-Destination-Field-in-SDriver-Struct

Are there any changes pending?
No

Does any team have to be notified of changes in this feature?
Yes
Definition of Done:

 - [ ] Is there >90% unit test code coverage?
    18.16%
  - [ ] Does this PR add new dependencies? If so, please list out the same.
  - [ ] Will this feature require a new piece of infrastructure to be implemented?
  - [x] Is there appropriate logging included?
  - [x] Does the project compile ok?
  - [x] Have Clippy violations been fixed?
  - [x] Have Code is properly formatted?